### PR TITLE
Fix three tote mode + fix clamp in AutoEjector.

### DIFF
--- a/QuasarHelios2015/src/org/team1540/quasarhelios/AutoEjector.java
+++ b/QuasarHelios2015/src/org/team1540/quasarhelios/AutoEjector.java
@@ -35,7 +35,7 @@ public class AutoEjector extends InstinctModule {
     @Override
     protected void autonomousMain() throws AutonomousModeOverException, InterruptedException {
         try {
-            float currentClampHeight = Clamp.heightOrSpeed.get();
+            float currentClampHeight = Clamp.height.get();
             setClampHeight(1.0f);
             Elevator.setBottom.event();
 
@@ -56,8 +56,8 @@ public class AutoEjector extends InstinctModule {
     }
     
     private void setClampHeight(float value) throws AutonomousModeOverException, InterruptedException {
-        Clamp.mode.set(false);
-        Clamp.heightOrSpeed.set(value);
+        Clamp.mode.set(Clamp.MODE_HEIGHT);
+        Clamp.height.set(value);
         waitUntil(FloatMixing.floatIsInRange(Clamp.heightReadout, value - clampHeightPadding.get(), value + clampHeightPadding.get()));
     }
 

--- a/QuasarHelios2015/src/org/team1540/quasarhelios/AutoEjector.java
+++ b/QuasarHelios2015/src/org/team1540/quasarhelios/AutoEjector.java
@@ -3,6 +3,7 @@ package org.team1540.quasarhelios;
 import ccre.channel.BooleanStatus;
 import ccre.channel.FloatInputPoll;
 import ccre.ctrl.BooleanMixing;
+import ccre.ctrl.FloatMixing;
 import ccre.igneous.Igneous;
 import ccre.instinct.AutonomousModeOverException;
 import ccre.instinct.InstinctModule;
@@ -10,6 +11,7 @@ import ccre.instinct.InstinctModule;
 public class AutoEjector extends InstinctModule {
     private final BooleanStatus running;
     private FloatInputPoll timeout = ControlInterface.mainTuning.getFloat("ejector-timeout", 2.0f);
+    private FloatInputPoll clampHeightPadding = ControlInterface.autoTuning.getFloat("auto-clamp-height-padding", 0.01f);
 
     private AutoEjector(BooleanStatus running) {
         this.running = running;
@@ -33,6 +35,8 @@ public class AutoEjector extends InstinctModule {
     @Override
     protected void autonomousMain() throws AutonomousModeOverException, InterruptedException {
         try {
+            float currentClampHeight = Clamp.heightOrSpeed.get();
+            setClampHeight(1.0f);
             Elevator.setBottom.event();
 
             waitUntil(Elevator.atBottom);
@@ -45,8 +49,16 @@ public class AutoEjector extends InstinctModule {
             waitForTime(timeout);
 
             Rollers.running.set(false);
+            setClampHeight(currentClampHeight);
         } finally {
             running.set(false);
         }
     }
+    
+    private void setClampHeight(float value) throws AutonomousModeOverException, InterruptedException {
+        Clamp.mode.set(false);
+        Clamp.heightOrSpeed.set(value);
+        waitUntil(FloatMixing.floatIsInRange(Clamp.heightReadout, value - clampHeightPadding.get(), value + clampHeightPadding.get()));
+    }
+
 }

--- a/QuasarHelios2015/src/org/team1540/quasarhelios/AutonomousModeThreeTotes.java
+++ b/QuasarHelios2015/src/org/team1540/quasarhelios/AutonomousModeThreeTotes.java
@@ -1,5 +1,6 @@
 package org.team1540.quasarhelios;
 
+import ccre.channel.BooleanInputPoll;
 import ccre.channel.FloatInputPoll;
 import ccre.holders.TuningContext;
 import ccre.instinct.AutonomousModeOverException;
@@ -9,6 +10,8 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
     public FloatInputPoll toteDistance;
     public FloatInputPoll autoZoneDistance;
     public FloatInputPoll strafeTime;
+    
+    public BooleanInputPoll containerToCollect; // true is first, false is second
 
     public AutonomousModeThreeTotes() {
         super("Three Tote Auto");
@@ -20,20 +23,24 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
         // Collect first tote + container
         setClampHeight(1.0f);
         collectTote();
-        setClampHeight(0.0f);
-        setClampOpen(true);
-        drive(nudge.get());
-        setClampOpen(false);
-        setClampHeight(1.0f);
+        if (containerToCollect.get()) {
+            setClampHeight(0.0f);
+            setClampOpen(true);
+            drive(nudge.get());
+            setClampOpen(false);
+            setClampHeight(1.0f);
+        }
         // TODO: Hold container with top claw
         drive(toteDistance.get());
         // Collect next tote + container
         collectTote();
-        setClampHeight(0.0f);
-        setClampOpen(true);
-        drive(nudge.get());
-        setClampOpen(false);
-        setClampHeight(1.0f);
+        if (!containerToCollect.get()) {
+            setClampHeight(0.0f);
+            setClampOpen(true);
+            drive(nudge.get());
+            setClampOpen(false);
+            setClampHeight(1.0f);
+        }
         drive(toteDistance.get());
         // Collect last tote and drive to auto zone
         collectTote();
@@ -46,8 +53,6 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
         DriveCode.octocanumShifting.set(true);
         strafe(1.0f, strafeTime.get());
         ejectTotes();
-        strafe(1.0f, strafeTime.get());
-        // TODO: Put down top container
         DriveCode.octocanumShifting.set(false);
     }
 
@@ -56,5 +61,6 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
         this.toteDistance = context.getFloat("auto-three-totes-tote-distance", 7.0f);
         this.autoZoneDistance = context.getFloat("auto-three-totes-auto-zone-distance", 5.0f);
         this.strafeTime = context.getFloat("auto-three-totes-strafe-time", 1.0f);
+        this.containerToCollect = context.getBoolean("auto-three-totes-container-to-collect", true);
     }
 }

--- a/QuasarHelios2015/src/org/team1540/quasarhelios/AutonomousModeThreeTotes.java
+++ b/QuasarHelios2015/src/org/team1540/quasarhelios/AutonomousModeThreeTotes.java
@@ -11,6 +11,7 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
     public FloatInputPoll autoZoneDistance;
     public FloatInputPoll strafeTime;
     
+    public BooleanInputPoll collectContainers;
     public BooleanInputPoll containerToCollect; // true is first, false is second
 
     public AutonomousModeThreeTotes() {
@@ -23,7 +24,7 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
         // Collect first tote + container
         setClampHeight(1.0f);
         collectTote();
-        if (containerToCollect.get()) {
+        if (containerToCollect.get() && collectContainers.get()) {
             setClampHeight(0.0f);
             setClampOpen(true);
             drive(nudge.get());
@@ -34,7 +35,7 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
         drive(toteDistance.get());
         // Collect next tote + container
         collectTote();
-        if (!containerToCollect.get()) {
+        if (!containerToCollect.get() && collectContainers.get()) {
             setClampHeight(0.0f);
             setClampOpen(true);
             drive(nudge.get());
@@ -47,11 +48,13 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
         turn(90);
         drive(autoZoneDistance.get());
         // Drop everything off
-        setClampHeight(0.0f);
-        setClampOpen(true);
-        setClampHeight(1.0f);
-        DriveCode.octocanumShifting.set(true);
-        strafe(1.0f, strafeTime.get());
+        if (collectContainers.get()) {
+            setClampHeight(0.0f);
+            setClampOpen(true);
+            setClampHeight(1.0f);
+            DriveCode.octocanumShifting.set(true);
+            strafe(1.0f, strafeTime.get());
+        }
         ejectTotes();
         DriveCode.octocanumShifting.set(false);
     }
@@ -62,5 +65,6 @@ public class AutonomousModeThreeTotes extends AutonomousModeBase {
         this.autoZoneDistance = context.getFloat("auto-three-totes-auto-zone-distance", 5.0f);
         this.strafeTime = context.getFloat("auto-three-totes-strafe-time", 1.0f);
         this.containerToCollect = context.getBoolean("auto-three-totes-container-to-collect", true);
+        this.collectContainers = context.getBoolean("auto-three-totes-collect-containers", true);
     }
 }

--- a/QuasarHelios2015/src/org/team1540/quasarhelios/AutonomousModeThreeTotes.java
+++ b/QuasarHelios2015/src/org/team1540/quasarhelios/AutonomousModeThreeTotes.java
@@ -6,13 +6,13 @@ import ccre.holders.TuningContext;
 import ccre.instinct.AutonomousModeOverException;
 
 public class AutonomousModeThreeTotes extends AutonomousModeBase {
-    public FloatInputPoll nudge;
-    public FloatInputPoll toteDistance;
-    public FloatInputPoll autoZoneDistance;
-    public FloatInputPoll strafeTime;
+    private FloatInputPoll nudge;
+    private FloatInputPoll toteDistance;
+    private FloatInputPoll autoZoneDistance;
+    private FloatInputPoll strafeTime;
     
-    public BooleanInputPoll collectContainers;
-    public BooleanInputPoll containerToCollect; // true is first, false is second
+    private BooleanInputPoll collectContainers;
+    private BooleanInputPoll containerToCollect; // true is first, false is second
 
     public AutonomousModeThreeTotes() {
         super("Three Tote Auto");


### PR DESCRIPTION
Setting `auto-three-tote-container-to-collect` on the Poultry Inspector will now determine which container to collect in three tote mode, and `auto-three-tote-collect-containers` controls whether to collect any containers in the first place.
